### PR TITLE
v0.13.70 — fpp-data code-quality standards: no curl|bash, FPP log naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ sudo systemctl restart apache2
 ```
 
 **Listener log location**
-`/home/fpp/media/logs/showpilot-listener.log`
+`/home/fpp/media/logs/plugin-showpilot.log`
 
 ```bash
-tail -f /home/fpp/media/logs/showpilot-listener.log
+tail -f /home/fpp/media/logs/plugin-showpilot.log
 ```
+
+**Audio daemon log location**
+`/home/fpp/media/logs/plugin-showpilot-audio.log`
 
 **Plugin queues wrong song**
 Make sure you've clicked **Sync Playlist** in the plugin UI after any changes to your FPP playlist contents/order.

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,4 +26,4 @@ disown
 
 echo
 echo -e "${GREEN}✓ Deploy complete. Tail the log to verify:${NC}"
-echo "  tail -f /home/fpp/media/logs/showpilot-listener.log"
+echo "  tail -f /home/fpp/media/logs/plugin-showpilot.log"

--- a/extract_audio.php
+++ b/extract_audio.php
@@ -43,7 +43,7 @@ include_once "/opt/fpp/www/common.php";
 // be either folder. config.php sets these globals.
 $musicDir = isset($musicDirectory) ? $musicDirectory : $settings['mediaDirectory'] . '/music';
 $videoDir = isset($videoDirectory) ? $videoDirectory : $settings['mediaDirectory'] . '/videos';
-$logFile = $settings['logDirectory'] . '/showpilot-listener.log';
+$logFile = $settings['logDirectory'] . '/plugin-showpilot.log';
 
 function elog($msg) {
     global $logFile;

--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -58,13 +58,21 @@ fi
 
 if [ "$NODE_OK" = "0" ]; then
     echo "Installing Node.js 22..."
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - 2>&1
+    # Add the NodeSource apt repo directly (GPG key + sources.list.d entry)
+    # instead of piping their setup script into a shell.
+    apt-get install -y ca-certificates gnupg
+    mkdir -p /etc/apt/keyrings
+    curl -fsSL --connect-timeout 10 --max-time 30 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list
+    apt-get update
     apt-get install -y nodejs 2>&1
     if command -v node >/dev/null 2>&1; then
         echo "Node.js $(node --version) installed successfully"
     else
         echo "WARN: Node.js installation failed — audio daemon will not start"
-        echo "WARN: Install manually: curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs"
+        echo "WARN: Install manually — see https://github.com/nodesource/distributions#installation-instructions"
     fi
 fi
 

--- a/scripts/postStart.sh
+++ b/scripts/postStart.sh
@@ -74,9 +74,9 @@ if command -v node >/dev/null 2>&1; then
         PORT="$AUDIO_PORT" \
         MEDIA_ROOT="/home/fpp/media/music" \
         FPP_HOST="http://127.0.0.1" \
-        LOG_FILE="$LOG_DIR/showpilot-audio.log" \
+        LOG_FILE="$LOG_DIR/plugin-showpilot-audio.log" \
         setsid /usr/bin/node --max-old-space-size=64 "$PLUGIN_DIR/showpilot_audio.js" \
-            </dev/null >>"$LOG_DIR/showpilot-audio.log" 2>&1 &
+            </dev/null >>"$LOG_DIR/plugin-showpilot-audio.log" 2>&1 &
     fi
 fi
 

--- a/scripts/restart-daemon.sh
+++ b/scripts/restart-daemon.sh
@@ -42,14 +42,14 @@ AUDIO_PORT=$(grep -E '^audioDaemonPort' "$CONFIG_FILE" 2>/dev/null | cut -d'"' -
 PORT="$AUDIO_PORT" \
 MEDIA_ROOT="/home/fpp/media/music" \
 FPP_HOST="http://127.0.0.1" \
-LOG_FILE="$LOG_DIR/showpilot-audio.log" \
+LOG_FILE="$LOG_DIR/plugin-showpilot-audio.log" \
 setsid /usr/bin/node --max-old-space-size=64 "$PLUGIN_DIR/showpilot_audio.js" \
-    </dev/null >>"$LOG_DIR/showpilot-audio.log" 2>&1 &
+    </dev/null >>"$LOG_DIR/plugin-showpilot-audio.log" 2>&1 &
 
 sleep 1
 NEW_PID=$(cat "$PID_FILE" 2>/dev/null)
 if [ -n "$NEW_PID" ] && kill -0 "$NEW_PID" 2>/dev/null; then
     echo "Daemon started (pid $NEW_PID)"
 else
-    echo "WARNING: daemon may not have started — check $LOG_DIR/showpilot-audio.log"
+    echo "WARNING: daemon may not have started — check $LOG_DIR/plugin-showpilot-audio.log"
 fi

--- a/showpilot_listener.php
+++ b/showpilot_listener.php
@@ -18,7 +18,7 @@ include_once "/opt/fpp/www/common.php";
 
 $pluginName = basename(dirname(__FILE__));
 $pluginPath = $settings['pluginDirectory'] . "/" . $pluginName . "/";
-$logFile = $settings['logDirectory'] . "/" . $pluginName . "-listener.log";
+$logFile = $settings['logDirectory'] . "/plugin-" . $pluginName . ".log";
 $pluginConfigFile = $settings['configDirectory'] . "/plugin." . $pluginName;
 
 function logEntry($data) {

--- a/version.php
+++ b/version.php
@@ -13,4 +13,4 @@
 // "0.10.0" in other files and update by hand — by design, no other file
 // has it.
 // ============================================================
-$PLUGIN_VERSION = "0.13.69";
+$PLUGIN_VERSION = "0.13.70";


### PR DESCRIPTION
Brings this plugin in line with the fpp-data pluginList.json review standards applied to ShowPilot-Lite's submission (low adoption so far, good time to adopt): NodeSource install now adds the apt repo directly (GPG key + sources.list.d entry) with curl timeouts, instead of piping the setup script into bash; listener/extract_audio logs move to plugin-showpilot.log and the audio daemon to
plugin-showpilot-audio.log, matching FPP's plugin-<name>.log log-viewer convention (was showpilot-listener.log / showpilot-audio.log).